### PR TITLE
Fix #1: harden path handling, packaging safety, and input limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Run Agent Skills reference checks
         run: python tests/scenarios/run_agentskills_reference_checks.py
 
+      - name: Run security regression tests
+        run: python tests/security/run_security_regressions.py
+
       - name: Package skills for Claude uploads
         run: python tools/package_skills_for_claude.py --output artifacts/claude-zips

--- a/skills/agentic-mcp-server-builder/scripts/scaffold_mcp_server.py
+++ b/skills/agentic-mcp-server-builder/scripts/scaffold_mcp_server.py
@@ -6,6 +6,8 @@ import csv
 import json
 from pathlib import Path
 
+MAX_INPUT_BYTES = 1_048_576
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Scaffold an MCP server starter package.")
@@ -13,15 +15,24 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output", required=True, help="Path to output artifact.")
     parser.add_argument("--format", choices=["json", "md", "csv"], default="json")
     parser.add_argument("--dry-run", action="store_true", help="Run without writing scaffold files.")
+    parser.add_argument(
+        "--allow-outside-workspace",
+        action="store_true",
+        help="Allow scaffold_root to resolve outside the current workspace.",
+    )
     return parser.parse_args()
 
 
-def load_payload(path: str | None) -> dict:
+def load_payload(path: str | None, max_input_bytes: int = MAX_INPUT_BYTES) -> dict:
     if not path:
         return {}
     input_path = Path(path)
     if not input_path.exists():
         raise FileNotFoundError(f"Input file not found: {input_path}")
+    if input_path.stat().st_size > max_input_bytes:
+        raise ValueError(
+            f"Input file exceeds {max_input_bytes} bytes: {input_path}"
+        )
     return json.loads(input_path.read_text(encoding="utf-8"))
 
 
@@ -30,6 +41,24 @@ def normalize_name(value: str) -> str:
     while "--" in cleaned:
         cleaned = cleaned.replace("--", "-")
     return cleaned.strip("-")
+
+
+def resolve_path_in_workspace(
+    raw_path: Path,
+    workspace_root: Path,
+    label: str,
+    allow_outside_workspace: bool,
+) -> Path:
+    resolved = raw_path.resolve()
+    if allow_outside_workspace:
+        return resolved
+    try:
+        resolved.relative_to(workspace_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"{label} must be inside workspace root: {workspace_root}"
+        ) from exc
+    return resolved
 
 
 def render(result: dict, output_path: Path, fmt: str) -> None:
@@ -79,7 +108,8 @@ def maybe_write_scaffold(root: Path, file_map: list[str], dry_run: bool) -> None
 def main() -> int:
     args = parse_args()
     payload = load_payload(args.input)
-    server_name = normalize_name(str(payload.get("server_name", "mcp-server")))
+    workspace_root = Path.cwd().resolve()
+    server_name = normalize_name(str(payload.get("server_name", "mcp-server"))) or "mcp-server"
     tools = payload.get("tools", [])
     if not isinstance(tools, list):
         tools = []
@@ -93,7 +123,13 @@ def main() -> int:
             }
         )
 
-    scaffold_root = Path(payload.get("scaffold_root", f"artifacts/{server_name}"))
+    raw_scaffold_root = Path(payload.get("scaffold_root", f"artifacts/{server_name}"))
+    scaffold_root = resolve_path_in_workspace(
+        raw_scaffold_root,
+        workspace_root,
+        "scaffold_root",
+        args.allow_outside_workspace,
+    )
     file_map = [
         "server.py",
         "tool_registry.py",

--- a/skills/agentic-workflow-automation/scripts/generate_workflow_blueprint.py
+++ b/skills/agentic-workflow-automation/scripts/generate_workflow_blueprint.py
@@ -6,6 +6,8 @@ import csv
 import json
 from pathlib import Path
 
+MAX_INPUT_BYTES = 1_048_576
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate a workflow automation blueprint.")
@@ -16,12 +18,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_payload(path: str | None) -> dict:
+def load_payload(path: str | None, max_input_bytes: int = MAX_INPUT_BYTES) -> dict:
     if not path:
         return {}
     input_path = Path(path)
     if not input_path.exists():
         raise FileNotFoundError(f"Input file not found: {input_path}")
+    if input_path.stat().st_size > max_input_bytes:
+        raise ValueError(f"Input file exceeds {max_input_bytes} bytes: {input_path}")
     return json.loads(input_path.read_text(encoding="utf-8"))
 
 

--- a/skills/cyber-ir-playbook/scripts/ir_timeline_report.py
+++ b/skills/cyber-ir-playbook/scripts/ir_timeline_report.py
@@ -15,6 +15,7 @@ PHASE_RULES = [
     ("recover", ["recover", "restore", "validate"]),
     ("post-incident", ["lessons", "postmortem", "review"]),
 ]
+MAX_INPUT_BYTES = 1_048_576
 
 
 def parse_args() -> argparse.Namespace:
@@ -26,12 +27,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_payload(path: str | None) -> dict:
+def load_payload(path: str | None, max_input_bytes: int = MAX_INPUT_BYTES) -> dict:
     if not path:
         return {}
     payload_path = Path(path)
     if not payload_path.exists():
         raise FileNotFoundError(f"Input file not found: {payload_path}")
+    if payload_path.stat().st_size > max_input_bytes:
+        raise ValueError(f"Input file exceeds {max_input_bytes} bytes: {payload_path}")
     return json.loads(payload_path.read_text(encoding="utf-8"))
 
 

--- a/skills/cyber-kev-triage/scripts/kev_triage.py
+++ b/skills/cyber-kev-triage/scripts/kev_triage.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 
 CRITICALITY_WEIGHT = {"critical": 3.0, "high": 2.0, "medium": 1.0, "low": 0.5}
+MAX_INPUT_BYTES = 1_048_576
 
 
 def parse_args() -> argparse.Namespace:
@@ -19,12 +20,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_payload(path: str | None) -> dict:
+def load_payload(path: str | None, max_input_bytes: int = MAX_INPUT_BYTES) -> dict:
     if not path:
         return {}
     data_path = Path(path)
     if not data_path.exists():
         raise FileNotFoundError(f"Input file not found: {data_path}")
+    if data_path.stat().st_size > max_input_bytes:
+        raise ValueError(f"Input file exceeds {max_input_bytes} bytes: {data_path}")
     return json.loads(data_path.read_text(encoding="utf-8"))
 
 

--- a/skills/cyber-owasp-review/scripts/map_findings_to_owasp.py
+++ b/skills/cyber-owasp-review/scripts/map_findings_to_owasp.py
@@ -19,6 +19,7 @@ OWASP_MAP = {
     "A09 Security Logging and Monitoring Failures": ["logging", "monitoring", "audit trail"],
     "A10 SSRF": ["ssrf", "server-side request forgery"],
 }
+MAX_INPUT_BYTES = 1_048_576
 
 
 def parse_args() -> argparse.Namespace:
@@ -30,12 +31,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_payload(path: str | None) -> dict:
+def load_payload(path: str | None, max_input_bytes: int = MAX_INPUT_BYTES) -> dict:
     if not path:
         return {}
     input_path = Path(path)
     if not input_path.exists():
         raise FileNotFoundError(f"Input file not found: {input_path}")
+    if input_path.stat().st_size > max_input_bytes:
+        raise ValueError(f"Input file exceeds {max_input_bytes} bytes: {input_path}")
     return json.loads(input_path.read_text(encoding="utf-8"))
 
 

--- a/skills/dl-transformer-finetune/scripts/build_finetune_plan.py
+++ b/skills/dl-transformer-finetune/scripts/build_finetune_plan.py
@@ -6,6 +6,8 @@ import csv
 import json
 from pathlib import Path
 
+MAX_INPUT_BYTES = 1_048_576
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Build a transformer fine-tuning plan.")
@@ -16,12 +18,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_payload(path: str | None) -> dict:
+def load_payload(path: str | None, max_input_bytes: int = MAX_INPUT_BYTES) -> dict:
     if not path:
         return {}
     p = Path(path)
     if not p.exists():
         raise FileNotFoundError(f"Input file not found: {p}")
+    if p.stat().st_size > max_input_bytes:
+        raise ValueError(f"Input file exceeds {max_input_bytes} bytes: {p}")
     return json.loads(p.read_text(encoding="utf-8"))
 
 

--- a/skills/docs-pipeline-automation/scripts/compose_docs_pipeline.py
+++ b/skills/docs-pipeline-automation/scripts/compose_docs_pipeline.py
@@ -6,6 +6,8 @@ import csv
 import json
 from pathlib import Path
 
+MAX_INPUT_BYTES = 1_048_576
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Compose a Docs pipeline specification.")
@@ -16,12 +18,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_payload(path: str | None) -> dict:
+def load_payload(path: str | None, max_input_bytes: int = MAX_INPUT_BYTES) -> dict:
     if not path:
         return {}
     payload_path = Path(path)
     if not payload_path.exists():
         raise FileNotFoundError(f"Input file not found: {payload_path}")
+    if payload_path.stat().st_size > max_input_bytes:
+        raise ValueError(f"Input file exceeds {max_input_bytes} bytes: {payload_path}")
     return json.loads(payload_path.read_text(encoding="utf-8"))
 
 

--- a/skills/google-workspace-automation/scripts/plan_workspace_automation.py
+++ b/skills/google-workspace-automation/scripts/plan_workspace_automation.py
@@ -14,6 +14,7 @@ SERVICE_SCOPES = {
     "calendar": "https://www.googleapis.com/auth/calendar",
     "docs": "https://www.googleapis.com/auth/documents",
 }
+MAX_INPUT_BYTES = 1_048_576
 
 
 def parse_args() -> argparse.Namespace:
@@ -25,12 +26,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_payload(path: str | None) -> dict:
+def load_payload(path: str | None, max_input_bytes: int = MAX_INPUT_BYTES) -> dict:
     if not path:
         return {}
     p = Path(path)
     if not p.exists():
         raise FileNotFoundError(f"Input file not found: {p}")
+    if p.stat().st_size > max_input_bytes:
+        raise ValueError(f"Input file exceeds {max_input_bytes} bytes: {p}")
     return json.loads(p.read_text(encoding="utf-8"))
 
 

--- a/skills/ml-experiment-tracker/scripts/build_experiment_plan.py
+++ b/skills/ml-experiment-tracker/scripts/build_experiment_plan.py
@@ -6,6 +6,8 @@ import csv
 import json
 from pathlib import Path
 
+MAX_INPUT_BYTES = 1_048_576
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Build a reproducible ML experiment plan.")
@@ -16,12 +18,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_payload(path: str | None) -> dict:
+def load_payload(path: str | None, max_input_bytes: int = MAX_INPUT_BYTES) -> dict:
     if not path:
         return {}
     p = Path(path)
     if not p.exists():
         raise FileNotFoundError(f"Input file not found: {p}")
+    if p.stat().st_size > max_input_bytes:
+        raise ValueError(f"Input file exceeds {max_input_bytes} bytes: {p}")
     return json.loads(p.read_text(encoding="utf-8"))
 
 

--- a/skills/ml-model-eval-benchmark/scripts/benchmark_models.py
+++ b/skills/ml-model-eval-benchmark/scripts/benchmark_models.py
@@ -6,6 +6,8 @@ import csv
 import json
 from pathlib import Path
 
+MAX_INPUT_BYTES = 1_048_576
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Benchmark model candidates using weighted metrics.")
@@ -16,12 +18,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_payload(path: str | None) -> dict:
+def load_payload(path: str | None, max_input_bytes: int = MAX_INPUT_BYTES) -> dict:
     if not path:
         return {}
     input_path = Path(path)
     if not input_path.exists():
         raise FileNotFoundError(f"Input file not found: {input_path}")
+    if input_path.stat().st_size > max_input_bytes:
+        raise ValueError(f"Input file exceeds {max_input_bytes} bytes: {input_path}")
     return json.loads(input_path.read_text(encoding="utf-8"))
 
 

--- a/skills/skill-creator-pro/scripts/generate_skill_starter.py
+++ b/skills/skill-creator-pro/scripts/generate_skill_starter.py
@@ -6,6 +6,8 @@ import csv
 import json
 from pathlib import Path
 
+MAX_INPUT_BYTES = 1_048_576
+
 
 CATEGORY_NOTES = {
     "cybersecurity": "Focus on defensive and tooling-centric workflows. Exclude exploit payload guidance.",
@@ -27,15 +29,22 @@ def parse_args() -> argparse.Namespace:
         required=False,
         help="Directory where skill scaffold should be created when dry-run is disabled.",
     )
+    parser.add_argument(
+        "--allow-outside-workspace",
+        action="store_true",
+        help="Allow --target-dir to resolve outside the current workspace.",
+    )
     return parser.parse_args()
 
 
-def load_input(path: str | None) -> dict:
+def load_input(path: str | None, max_input_bytes: int = MAX_INPUT_BYTES) -> dict:
     if not path:
         return {}
     p = Path(path)
     if not p.exists():
         raise FileNotFoundError(f"Input file not found: {p}")
+    if p.stat().st_size > max_input_bytes:
+        raise ValueError(f"Input file exceeds {max_input_bytes} bytes: {p}")
     return json.loads(p.read_text(encoding="utf-8"))
 
 
@@ -44,6 +53,24 @@ def normalize_name(raw: str) -> str:
     while "--" in cleaned:
         cleaned = cleaned.replace("--", "-")
     return cleaned.strip("-")
+
+
+def resolve_path_in_workspace(
+    raw_path: Path,
+    workspace_root: Path,
+    label: str,
+    allow_outside_workspace: bool,
+) -> Path:
+    resolved = raw_path.resolve()
+    if allow_outside_workspace:
+        return resolved
+    try:
+        resolved.relative_to(workspace_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"{label} must be inside workspace root: {workspace_root}"
+        ) from exc
+    return resolved
 
 
 def build_skill_md(skill_name: str, description: str, note: str) -> str:
@@ -101,12 +128,20 @@ def maybe_scaffold(
     note: str,
     target_dir: Path | None,
     dry_run: bool,
+    workspace_root: Path,
+    allow_outside_workspace: bool,
 ) -> list[str]:
     artifacts: list[str] = []
     if target_dir is None:
         return artifacts
 
-    skill_dir = target_dir / skill_name
+    safe_target_dir = resolve_path_in_workspace(
+        target_dir,
+        workspace_root,
+        "target_dir",
+        allow_outside_workspace,
+    )
+    skill_dir = safe_target_dir / skill_name
     artifacts.extend(
         [
             str(skill_dir / "SKILL.md"),
@@ -148,8 +183,9 @@ def maybe_scaffold(
 def main() -> int:
     args = parse_args()
     payload = load_input(args.input)
+    workspace_root = Path.cwd().resolve()
     raw_name = payload.get("skill_name", "new-skill")
-    skill_name = normalize_name(raw_name)
+    skill_name = normalize_name(raw_name) or "new-skill"
     category = str(payload.get("category", "general")).lower().strip()
     description = str(
         payload.get(
@@ -160,7 +196,15 @@ def main() -> int:
 
     note = CATEGORY_NOTES.get(category, CATEGORY_NOTES["general"])
     target_dir = Path(args.target_dir) if args.target_dir else None
-    artifacts = maybe_scaffold(skill_name, description, note, target_dir, args.dry_run)
+    artifacts = maybe_scaffold(
+        skill_name,
+        description,
+        note,
+        target_dir,
+        args.dry_run,
+        workspace_root,
+        args.allow_outside_workspace,
+    )
 
     result = {
         "status": "ok",

--- a/skills/skill-creator-pro/scripts/validate_skill_pack.py
+++ b/skills/skill-creator-pro/scripts/validate_skill_pack.py
@@ -12,6 +12,7 @@ import yaml
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
 MAX_COMPATIBILITY_LENGTH = 500
+MAX_INPUT_BYTES = 1_048_576
 ALLOWED_FRONTMATTER_KEYS = {
     "name",
     "description",
@@ -31,12 +32,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_input(path: str | None) -> dict:
+def load_input(path: str | None, max_input_bytes: int = MAX_INPUT_BYTES) -> dict:
     if not path:
         return {}
     p = Path(path)
     if not p.exists():
         raise FileNotFoundError(f"Input file not found: {p}")
+    if p.stat().st_size > max_input_bytes:
+        raise ValueError(f"Input file exceeds {max_input_bytes} bytes: {p}")
     return json.loads(p.read_text(encoding="utf-8"))
 
 

--- a/tests/scenarios/run_agentic_scenarios.py
+++ b/tests/scenarios/run_agentic_scenarios.py
@@ -228,6 +228,7 @@ def run_agentic_automation_scenario(temp_dir: Path) -> dict:
         mcp_payload,
         temp_dir,
         dry_run=False,
+        extra_args=["--allow-outside-workspace"],
     )
     assert isinstance(mcp_result, dict)
     for relative_file in mcp_result["details"]["file_map"]:
@@ -310,7 +311,7 @@ def run_skill_lifecycle_scenario(temp_dir: Path) -> dict:
         starter_payload,
         temp_dir,
         dry_run=False,
-        extra_args=["--target-dir", str(generated_root)],
+        extra_args=["--target-dir", str(generated_root), "--allow-outside-workspace"],
     )
     assert isinstance(starter_result, dict)
     generated_skill_dir = generated_root / starter_result["details"]["skill_name"]

--- a/tests/security/run_security_regressions.py
+++ b/tests/security/run_security_regressions.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MAX_INPUT_BYTES = 1_048_576
+
+
+class SecurityTestError(RuntimeError):
+    pass
+
+
+def run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def assert_fails_with(proc: subprocess.CompletedProcess[str], expected_text: str, label: str) -> None:
+    if proc.returncode == 0:
+        raise SecurityTestError(f"{label}: expected failure but command succeeded")
+    merged = f"{proc.stdout}\n{proc.stderr}"
+    if expected_text not in merged:
+        raise SecurityTestError(
+            f"{label}: expected text '{expected_text}' not found\nstdout={proc.stdout}\nstderr={proc.stderr}"
+        )
+
+
+def test_scaffold_root_boundary() -> str:
+    script = ROOT / "skills" / "agentic-mcp-server-builder" / "scripts" / "scaffold_mcp_server.py"
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        input_path = tmpdir / "input.json"
+        output_path = tmpdir / "output.json"
+        write_json(
+            input_path,
+            {
+                "server_name": "ops-helper",
+                "scaffold_root": "../outside-workspace",
+                "tools": [{"name": "list", "description": "list incidents"}],
+            },
+        )
+        proc = run(
+            [
+                sys.executable,
+                str(script),
+                "--input",
+                str(input_path),
+                "--output",
+                str(output_path),
+                "--format",
+                "json",
+                "--dry-run",
+            ],
+            cwd=ROOT,
+        )
+        assert_fails_with(proc, "scaffold_root must be inside workspace root", "scaffold_root_boundary")
+    return "scaffold_root traversal blocked"
+
+
+def test_target_dir_boundary() -> str:
+    script = ROOT / "skills" / "skill-creator-pro" / "scripts" / "generate_skill_starter.py"
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        input_path = tmpdir / "input.json"
+        output_path = tmpdir / "output.json"
+        write_json(
+            input_path,
+            {
+                "skill_name": "secure-test-skill",
+                "category": "general",
+                "description": "Boundary test skill.",
+            },
+        )
+        proc = run(
+            [
+                sys.executable,
+                str(script),
+                "--input",
+                str(input_path),
+                "--output",
+                str(output_path),
+                "--format",
+                "json",
+                "--dry-run",
+                "--target-dir",
+                "../outside-skill-root",
+            ],
+            cwd=ROOT,
+        )
+        assert_fails_with(proc, "target_dir must be inside workspace root", "target_dir_boundary")
+    return "target_dir traversal blocked"
+
+
+def test_allow_outside_workspace_flag() -> str:
+    script = ROOT / "skills" / "agentic-mcp-server-builder" / "scripts" / "scaffold_mcp_server.py"
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        input_path = tmpdir / "input.json"
+        output_path = tmpdir / "output.json"
+        write_json(
+            input_path,
+            {
+                "server_name": "ops-helper",
+                "scaffold_root": str(tmpdir / "outside-allowed"),
+                "tools": [{"name": "list", "description": "list incidents"}],
+            },
+        )
+        proc = run(
+            [
+                sys.executable,
+                str(script),
+                "--input",
+                str(input_path),
+                "--output",
+                str(output_path),
+                "--format",
+                "json",
+                "--dry-run",
+                "--allow-outside-workspace",
+            ],
+            cwd=ROOT,
+        )
+        if proc.returncode != 0:
+            raise SecurityTestError(
+                "allow_outside_workspace_flag: expected success with explicit override\n"
+                f"stdout={proc.stdout}\nstderr={proc.stderr}"
+            )
+        if not output_path.exists():
+            raise SecurityTestError("allow_outside_workspace_flag: output artifact missing")
+    return "outside workspace override works"
+
+
+def test_oversized_input_rejected() -> str:
+    script = ROOT / "skills" / "ml-experiment-tracker" / "scripts" / "build_experiment_plan.py"
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        input_path = tmpdir / "oversized.json"
+        output_path = tmpdir / "output.json"
+        payload = {"blob": "A" * (MAX_INPUT_BYTES + 256)}
+        write_json(input_path, payload)
+
+        proc = run(
+            [
+                sys.executable,
+                str(script),
+                "--input",
+                str(input_path),
+                "--output",
+                str(output_path),
+                "--format",
+                "json",
+                "--dry-run",
+            ],
+            cwd=ROOT,
+        )
+        assert_fails_with(proc, "Input file exceeds", "oversized_input_rejected")
+    return "oversized payload rejected"
+
+
+def test_packaging_rejects_symlink() -> str:
+    script = ROOT / "tools" / "package_skills_for_claude.py"
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        skills_dir = tmpdir / "skills"
+        skill_dir = skills_dir / "sample-skill"
+        output_dir = tmpdir / "zips"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: sample-skill\ndescription: Security packaging test.\n---\n",
+            encoding="utf-8",
+        )
+        (skill_dir / "agents").mkdir(parents=True, exist_ok=True)
+        (skill_dir / "agents" / "openai.yaml").write_text(
+            "interface:\n"
+            "  display_name: \"Sample Skill\"\n"
+            "  short_description: \"Sample security packaging validation\"\n"
+            "  default_prompt: \"Use $sample-skill for packaging checks.\"\n",
+            encoding="utf-8",
+        )
+        (skill_dir / "scripts").mkdir(parents=True, exist_ok=True)
+        (skill_dir / "scripts" / "run.py").write_text("print('ok')\n", encoding="utf-8")
+
+        secret_file = tmpdir / "secret.txt"
+        secret_file.write_text("sensitive-data\n", encoding="utf-8")
+        link_path = skill_dir / "leak.txt"
+        try:
+            link_path.symlink_to(secret_file)
+        except OSError as exc:
+            return f"symlink test skipped ({exc.__class__.__name__})"
+
+        proc = run(
+            [
+                sys.executable,
+                str(script),
+                "--skills-dir",
+                str(skills_dir),
+                "--output",
+                str(output_dir),
+            ],
+            cwd=ROOT,
+        )
+        assert_fails_with(proc, "Packaging aborted", "packaging_rejects_symlink")
+    return "packaging rejects symlink/reparse paths"
+
+
+def main() -> int:
+    checks = [
+        test_scaffold_root_boundary,
+        test_target_dir_boundary,
+        test_allow_outside_workspace_flag,
+        test_oversized_input_rejected,
+        test_packaging_rejects_symlink,
+    ]
+    results: list[str] = []
+
+    for check in checks:
+        results.append(check())
+
+    print(json.dumps({"status": "ok", "checks": results}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SecurityTestError as exc:
+        print(f"Security regression test failure: {exc}")
+        raise SystemExit(1)

--- a/tools/package_skills_for_claude.py
+++ b/tools/package_skills_for_claude.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import argparse
+import os
+import stat
 from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile
 
@@ -27,13 +29,50 @@ def iter_skill_dirs(skills_dir: Path) -> list[Path]:
     return sorted([path for path in skills_dir.iterdir() if path.is_dir()])
 
 
+def is_link_or_reparse(path: Path) -> bool:
+    if path.is_symlink():
+        return True
+    st = path.lstat()
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    return bool(getattr(st, "st_file_attributes", 0) & reparse_flag)
+
+
+def iter_skill_files(skill_dir: Path) -> list[Path]:
+    collected: list[Path] = []
+    for root, dirs, files in os.walk(skill_dir, followlinks=False):
+        root_path = Path(root)
+
+        blocked_dirs = []
+        safe_dirs = []
+        for name in dirs:
+            child = root_path / name
+            if is_link_or_reparse(child):
+                blocked_dirs.append(str(child))
+            else:
+                safe_dirs.append(name)
+        if blocked_dirs:
+            raise ValueError(
+                "Refusing to package symlink/reparse directories: "
+                + ", ".join(blocked_dirs)
+            )
+        dirs[:] = safe_dirs
+
+        for name in files:
+            child = root_path / name
+            if is_link_or_reparse(child):
+                raise ValueError(
+                    f"Refusing to package symlink/reparse file: {child}"
+                )
+            collected.append(child)
+
+    return sorted(collected)
+
+
 def create_zip(skill_dir: Path, output_dir: Path) -> Path:
     output_dir.mkdir(parents=True, exist_ok=True)
     zip_path = output_dir / f"{skill_dir.name}.zip"
     with ZipFile(zip_path, "w", compression=ZIP_DEFLATED) as zf:
-        for path in sorted(skill_dir.rglob("*")):
-            if path.is_dir():
-                continue
+        for path in iter_skill_files(skill_dir):
             rel_inside_skill = path.relative_to(skill_dir)
             archive_name = Path(skill_dir.name) / rel_inside_skill
             zf.write(path, archive_name.as_posix())
@@ -55,8 +94,12 @@ def main() -> int:
         return 1
 
     built = []
-    for skill_dir in skill_dirs:
-        built.append(create_zip(skill_dir, output_dir))
+    try:
+        for skill_dir in skill_dirs:
+            built.append(create_zip(skill_dir, output_dir))
+    except ValueError as exc:
+        print(f"Packaging aborted: {exc}")
+        return 1
 
     print(f"Packaged {len(built)} skills to {output_dir}")
     return 0

--- a/tools/run_checks.bat
+++ b/tools/run_checks.bat
@@ -16,6 +16,9 @@ if errorlevel 1 exit /b 1
 python tests\scenarios\run_agentskills_reference_checks.py
 if errorlevel 1 exit /b 1
 
+python tests\security\run_security_regressions.py
+if errorlevel 1 exit /b 1
+
 python tools\package_skills_for_claude.py --output artifacts\claude-zips
 if errorlevel 1 exit /b 1
 


### PR DESCRIPTION
## Summary
- enforce workspace-boundary checks for scaffold write targets
- add explicit `--allow-outside-workspace` override for intentional external paths
- block symlink/reparse-point inclusion during skill zip packaging
- reject oversized JSON payloads in skill scripts
- add security regression tests and wire them into CI + local checks

## Validation
- `tools/run_checks.bat` passes
- includes validate, smoke, scenario, reference, security regression, and packaging checks

Closes #1


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened path handling and packaging to block path traversal and symlink leaks, and enforced a 1 MB limit on JSON inputs across skills. Added security regression tests and wired them into CI for ongoing coverage.

- **New Features**
  - Enforce workspace-boundary for scaffold_root/--target-dir; add --allow-outside-workspace override.
  - Reject JSON inputs larger than 1 MB across all skill scripts.
  - Packaging aborts on symlink/reparse files and directories.
  - Security regression tests added; CI and tools/run_checks.bat now run them.

- **Migration**
  - If you intentionally write outside the repo, pass --allow-outside-workspace in scaffolding/skill starter commands.
  - Update any scripts or automations that assumed external paths to include the flag.

<sup>Written for commit 4ab85db53338267021bde05fc648af4541083e8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

