### PR TITLE
fix: address web-builder follow-up review issues

### DIFF
--- a/skills/skill-creator-pro/scripts/validate_skill_pack.py
+++ b/skills/skill-creator-pro/scripts/validate_skill_pack.py
@@ -181,6 +181,19 @@ def write_output(result: dict, output_path: Path, fmt: str) -> None:
             writer.writerow(["error", err])
 
 
+def is_candidate_skill_dir(path: Path) -> bool:
+    if not path.is_dir():
+        return False
+    if (path / "SKILL.md").exists():
+        return True
+    if (path / "agents" / "openai.yaml").exists():
+        return True
+    scripts_dir = path / "scripts"
+    if scripts_dir.exists() and any(scripts_dir.glob("*.py")):
+        return True
+    return False
+
+
 def main() -> int:
     args = parse_args()
     payload = load_input(args.input)
@@ -197,9 +210,7 @@ def main() -> int:
         return 1
 
     errors: list[str] = []
-    skill_dirs = sorted(
-        [path for path in skill_root.iterdir() if path.is_dir() and (path / "SKILL.md").exists()]
-    )
+    skill_dirs = sorted([path for path in skill_root.iterdir() if is_candidate_skill_dir(path)])
     for skill_dir in skill_dirs:
         errors.extend(validate_skill(skill_dir))
 

--- a/skills/web-api-tester/scripts/api_tester.py
+++ b/skills/web-api-tester/scripts/api_tester.py
@@ -136,10 +136,14 @@ def main() -> int:
         }
         api_report_path.write_text(json.dumps(api_report_payload, indent=2), encoding="utf-8")
 
+    artifacts = [str(report_path)]
+    if not args.dry_run:
+        artifacts = [str(api_report_path), str(test_matrix_path), str(report_path)]
+
     result = {
         "status": status,
         "summary": "Generated API test coverage plan from OpenAPI contract",
-        "artifacts": [str(api_report_path), str(test_matrix_path), str(report_path)],
+        "artifacts": artifacts,
         "details": {
             "openapi_path": str(openapi_path) if openapi_path else "",
             "endpoint_count": len(endpoints),

--- a/skills/web-auth-integrator/scripts/auth_integrator.py
+++ b/skills/web-auth-integrator/scripts/auth_integrator.py
@@ -149,10 +149,14 @@ def main() -> int:
         }
         auth_report_path.write_text(json.dumps(auth_report_payload, indent=2), encoding="utf-8")
 
+    artifacts = [str(report_path)]
+    if not args.dry_run:
+        artifacts = [str(auth_report_path), str(checklist_md_path), str(report_path)]
+
     result = {
         "status": "ok" if config_path else "warning",
         "summary": "Generated provider-specific authentication integration plan",
-        "artifacts": [str(auth_report_path), str(checklist_md_path), str(report_path)],
+        "artifacts": artifacts,
         "details": {
             "project_config_path": str(config_path) if config_path else "",
             "auth_provider": provider,

--- a/skills/web-backend-builder/scripts/backend_builder.py
+++ b/skills/web-backend-builder/scripts/backend_builder.py
@@ -229,10 +229,14 @@ def main() -> int:
         }
         backend_report_path.write_text(json.dumps(backend_report_payload, indent=2), encoding="utf-8")
 
+    artifacts = [str(report_path)]
+    if not args.dry_run:
+        artifacts = [str(openapi_path), str(backend_report_path), str(report_path)] + created
+
     result = {
         "status": "ok" if config_path else "warning",
         "summary": "Generated backend framework, ORM, and API contract plan",
-        "artifacts": [str(openapi_path), str(backend_report_path), str(report_path)] + created,
+        "artifacts": artifacts,
         "details": {
             "project_config_path": str(config_path) if config_path else "",
             "backend": backend,

--- a/skills/web-database-validator/scripts/database_validator.py
+++ b/skills/web-database-validator/scripts/database_validator.py
@@ -157,10 +157,18 @@ def main() -> int:
         }
         db_report_path.write_text(json.dumps(db_payload, indent=2), encoding="utf-8")
 
+    result_status = status
+    if not config_path and result_status == "ok":
+        result_status = "warning"
+
+    artifacts = [str(report_path)]
+    if not args.dry_run:
+        artifacts.insert(0, str(db_report_path))
+
     result = {
-        "status": status if config_path else "warning",
+        "status": result_status,
         "summary": "Evaluated database migration and schema quality checks",
-        "artifacts": [str(db_report_path), str(report_path)],
+        "artifacts": artifacts,
         "details": {
             "project_config_path": str(config_path) if config_path else "",
             "database": config.get("stack", {}).get("database", "unknown")

--- a/skills/web-deploy-launcher/scripts/deploy_launcher.py
+++ b/skills/web-deploy-launcher/scripts/deploy_launcher.py
@@ -202,10 +202,14 @@ def main() -> int:
         }
         deploy_report_path.write_text(json.dumps(deploy_payload, indent=2), encoding="utf-8")
 
+    artifacts = [str(report_path)]
+    if not args.dry_run:
+        artifacts = [str(deploy_report_path), str(deployment_md_path), str(report_path)] + created_files
+
     result = {
         "status": status if config_path else "warning",
         "summary": "Prepared deployment config and launch readiness checklist",
-        "artifacts": [str(deploy_report_path), str(deployment_md_path), str(report_path)] + created_files,
+        "artifacts": artifacts,
         "details": {
             "project_config_path": str(config_path) if config_path else "",
             "deployment_target": deployment_target,

--- a/skills/web-frontend-designer/scripts/frontend_designer.py
+++ b/skills/web-frontend-designer/scripts/frontend_designer.py
@@ -109,6 +109,20 @@ def sanitize_route_to_file(route: str) -> str:
     return cleaned
 
 
+def resolve_next_app_page_file(route_root: Path, route: str) -> Path:
+    segments = [segment for segment in route.strip("/").split("/") if segment]
+    if not segments:
+        return route_root / "page.tsx"
+
+    normalized_segments: list[str] = []
+    for segment in segments:
+        if segment.startswith(":") and len(segment) > 1:
+            normalized_segments.append(f"[{segment[1:]}]")
+        else:
+            normalized_segments.append(segment)
+    return route_root.joinpath(*normalized_segments) / "page.tsx"
+
+
 def scaffold_frontend(frontend_root: Path, routes: list[str], framework: str) -> list[str]:
     created: list[str] = []
     dirs = [frontend_root / "components", frontend_root / "layouts", frontend_root / "public"]
@@ -122,9 +136,34 @@ def scaffold_frontend(frontend_root: Path, routes: list[str], framework: str) ->
         created.append(str(dpath))
 
     route_root = frontend_root / ("app" if framework == "next.js" else "pages")
+    if framework == "next.js":
+        layout_file = route_root / "layout.tsx"
+        layout_file.write_text(
+            "\n".join(
+                [
+                    "import type { ReactNode } from \"react\";",
+                    "",
+                    "export default function RootLayout({ children }: { children: ReactNode }) {",
+                    "  return (",
+                    "    <html lang=\"en\">",
+                    "      <body>{children}</body>",
+                    "    </html>",
+                    "  );",
+                    "}",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        created.append(str(layout_file))
+
     for route in routes:
-        filename = sanitize_route_to_file(route)
-        page_file = route_root / f"{filename}.tsx"
+        if framework == "next.js":
+            page_file = resolve_next_app_page_file(route_root, route)
+        else:
+            filename = sanitize_route_to_file(route)
+            page_file = route_root / f"{filename}.tsx"
+        page_file.parent.mkdir(parents=True, exist_ok=True)
         page_file.write_text(
             "\n".join(
                 [
@@ -219,10 +258,14 @@ def main() -> int:
         }
         frontend_report.write_text(json.dumps(frontend_report_payload, indent=2), encoding="utf-8")
 
+    artifacts = [str(report_path)]
+    if not args.dry_run:
+        artifacts = [str(frontend_report), str(report_path)] + created_paths
+
     result = {
         "status": "ok" if config_path else "warning",
         "summary": "Generated frontend scaffold plan and dependency inventory",
-        "artifacts": [str(frontend_report), str(report_path)] + created_paths,
+        "artifacts": artifacts,
         "details": {
             "project_config_path": str(config_path) if config_path else "",
             "framework": framework,

--- a/skills/web-frontend-tester/scripts/frontend_tester.py
+++ b/skills/web-frontend-tester/scripts/frontend_tester.py
@@ -120,10 +120,14 @@ def main() -> int:
         }
         frontend_test_report.write_text(json.dumps(frontend_payload, indent=2), encoding="utf-8")
 
+    artifacts = [str(report_path)]
+    if not args.dry_run:
+        artifacts = [str(frontend_test_report), str(lighthouse_path), str(report_path)]
+
     result = {
         "status": status if config_path else "warning",
         "summary": "Generated frontend E2E, a11y, visual, and performance test plan",
-        "artifacts": [str(frontend_test_report), str(lighthouse_path), str(report_path)],
+        "artifacts": artifacts,
         "details": {
             "project_config_path": str(config_path) if config_path else "",
             "playwright_journeys": journeys,

--- a/skills/web-stack-planner/scripts/stack_planner.py
+++ b/skills/web-stack-planner/scripts/stack_planner.py
@@ -70,6 +70,8 @@ DEPLOY_OPTIONS = [
     "digitalocean",
     "cloudflare pages",
 ]
+TRUE_STRINGS = {"true", "1", "yes", "y", "on"}
+FALSE_STRINGS = {"false", "0", "no", "n", "off", ""}
 
 
 def parse_args() -> argparse.Namespace:
@@ -122,6 +124,22 @@ def normalize_list(raw: Any, allowed: list[str]) -> list[str]:
         if lower in allowed and lower not in normalized:
             normalized.append(lower)
     return normalized
+
+
+def parse_bool(raw: Any, default: bool = False) -> tuple[bool, bool]:
+    if raw is None:
+        return default, True
+    if isinstance(raw, bool):
+        return raw, True
+    if isinstance(raw, (int, float)):
+        return bool(raw), True
+    if isinstance(raw, str):
+        value = raw.strip().lower()
+        if value in TRUE_STRINGS:
+            return True, True
+        if value in FALSE_STRINGS:
+            return False, True
+    return default, False
 
 
 def build_config(payload: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
@@ -193,7 +211,12 @@ def build_config(payload: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
         warnings,
         "storage provider",
     )
-    i18n_enabled = bool(integrations.get("i18n", payload.get("i18n", False)))
+    i18n_raw = integrations.get("i18n")
+    if i18n_raw is None:
+        i18n_raw = payload.get("i18n", False)
+    i18n_enabled, i18n_valid = parse_bool(i18n_raw, default=False)
+    if not i18n_valid:
+        warnings.append(f"Unsupported i18n value '{i18n_raw}', fallback to 'false'")
 
     config = {
         "project_name": project_name,
@@ -267,10 +290,14 @@ def main() -> int:
     if not args.dry_run:
         config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
 
+    artifacts = [str(report_path)]
+    if not args.dry_run:
+        artifacts.insert(0, str(config_path))
+
     result = {
         "status": "warning" if warnings else "ok",
         "summary": "Validated stack selections and prepared canonical project config",
-        "artifacts": [str(config_path), str(report_path)],
+        "artifacts": artifacts,
         "details": {
             "project_config": config,
             "validation_warnings": warnings,

--- a/skills/web-ux-architect/scripts/ux_architect.py
+++ b/skills/web-ux-architect/scripts/ux_architect.py
@@ -194,10 +194,14 @@ def main() -> int:
         }
         ux_report_path.write_text(json.dumps(ux_payload, indent=2), encoding="utf-8")
 
+    artifacts = [str(report_path)]
+    if not args.dry_run:
+        artifacts = [str(sitemap_path), str(wireframes_path), str(ux_report_path), str(report_path)]
+
     result = {
         "status": "ok" if config_path else "warning",
         "summary": "Generated UX architecture plan from project config",
-        "artifacts": [str(sitemap_path), str(wireframes_path), str(ux_report_path), str(report_path)],
+        "artifacts": artifacts,
         "details": {
             "project_config_path": str(config_path) if config_path else "",
             "project_type": project_type,


### PR DESCRIPTION
## Summary
- fix skill pack validator to still detect malformed skill dirs missing SKILL.md
- fix i18n boolean parsing in stack planner
- fix dry-run artifact reporting so only actually created artifacts are listed
- preserve real failure status in database validator when config is missing
- add Next.js app-router scaffold completeness (app/layout.tsx and route page.tsx layout)

## Validation
- tools/run_checks.bat

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes follow-up review issues across web-builder skills to improve validation accuracy, dry-run artifact reporting, and Next.js scaffolding. Results in more reliable reports and a complete Next.js app-router setup.

- **Bug Fixes**
  - Skill pack validator now detects candidate skill directories even without SKILL.md.
  - Stack planner correctly parses i18n booleans from strings and numbers; adds a warning on invalid values.
  - Dry-run modes list only actually created artifacts across all web skills.
  - Database validator preserves real failure status even when config is missing.

- **New Features**
  - Next.js app-router scaffolding adds app/layout.tsx and creates app/page.tsx files for nested and dynamic routes.

<sup>Written for commit 2f6dd2ac4ac05196b11f6580faba3071e52c4dc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

