### PR TITLE
feat: add nmap-pentest-scans skill pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Run bug bounty pentest scenarios
         run: python tests/scenarios/test_pentest_bug_bounty_programs.py
 
+      - name: Run nmap pentest regression scenario
+        run: python tests/scenarios/test_nmap_pentest_scans_regression.py
+
       - name: Run scenario tests
         run: python tests/scenarios/run_agentic_scenarios.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented in this file.
 
 The format follows Keep a Changelog principles and uses Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+- Added `nmap-pentest-scans` skill with scope-validated Nmap planning workflow, command templates, and deterministic output artifacts.
+
 ## [v3.0.2] - 2026-02-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ This repository focuses on deterministic skill contracts, strong validation, and
 
 ## Skill Packs
 
-This repository ships 43 production-ready skills:
+This repository ships 44 production-ready skills:
 - 1 meta skill: `skill-creator-pro`
-- 42 domain skills across cybersecurity, AI/ML+DL, agentic AI, daily automation, web engineering, and authorized pentest operations
+- 43 domain skills across cybersecurity, AI/ML+DL, agentic AI, daily automation, web engineering, and authorized pentest operations
 
 ### Web Builder Skills
 
@@ -77,6 +77,7 @@ This repository ships 43 production-ready skills:
 - `pentest-redteam-ops`
 - `pentest-report-generator`
 - `pentest-remediation-validator`
+- `nmap-pentest-scans`
 
 ## Skill Contract
 

--- a/skills/nmap-pentest-scans/SKILL.md
+++ b/skills/nmap-pentest-scans/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: nmap-pentest-scans
+description: Plan and orchestrate authorized Nmap host discovery, port and service enumeration, NSE profiling, and reporting artifacts for in-scope targets.
+---
+
+# Nmap Pentest Scans
+
+## Stage
+
+- PTES: 2-3
+- MITRE: TA0007 - Discovery
+
+## Objective
+
+Design reproducible Nmap scan workflows for authorized targets and produce deterministic scan-plan artifacts.
+
+## Required Workflow
+
+1. Validate scope before any active action and reject out-of-scope targets.
+2. Require explicit authorization for non-dry-run execution.
+3. Select profile (stealth, balanced, fast) and build command sequence.
+4. Produce normalized findings and export deterministic artifacts.
+
+## Execution
+
+```bash
+python skills/nmap-pentest-scans/scripts/nmap_pentest_scans.py --scope scope.json --target <target> --input <path> --output <path> --format json --dry-run
+```
+
+## Outputs
+
+- `scan-plan.json`
+- `scan-plan.md`
+- `recommended-commands.txt`
+- `findings/nmap-pentest-findings.json`
+- `nmap-pentest-scans-report.json`
+
+## References
+
+- `references/tools.md`
+- `references/scan-profiles.md`
+- `skills/autonomous-pentester/shared/scope_schema.json`
+- `skills/autonomous-pentester/shared/finding_schema.json`
+
+## Legal and Ethical Notice
+
+```text
+WARNING AUTHORIZED USE ONLY
+This skill prepares and can orchestrate live network scan workflows.
+Use only with written authorization and approved scope.
+```

--- a/skills/nmap-pentest-scans/agents/openai.yaml
+++ b/skills/nmap-pentest-scans/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Nmap Pro Pentest Scans"
+  short_description: "Build pro-grade Nmap scan plans and commands"
+  default_prompt: "Use $nmap-pentest-scans to pick and run the right Nmap scans for discovery, enumeration, and NSE checks."

--- a/skills/nmap-pentest-scans/references/scan-profiles.md
+++ b/skills/nmap-pentest-scans/references/scan-profiles.md
@@ -1,0 +1,300 @@
+# Nmap Scan Profiles
+
+Use this reference to pick command templates quickly during authorized penetration tests.
+
+## Table of Contents
+
+1. Variables and Conventions
+2. Baseline Setup
+3. Host Discovery Profiles
+4. Port Scan Profiles
+5. Service and OS Fingerprinting
+6. NSE Script Profiles
+7. Firewall and Evasion Options
+8. Performance and Reliability Tuning
+9. Professional Runbooks
+10. Output and Reporting
+11. Common Pitfalls
+
+## 1) Variables and Conventions
+
+- Replace `<TARGET>` with host, CIDR, or range.
+- Replace `<TARGETS_FILE>` with a newline-separated target list.
+- Replace `<OUT>` with output prefix, for example `results/external-week1`.
+- Run privileged scans as Administrator/root when required (`-sS`, raw packet features).
+- Save outputs with `-oA <OUT>` whenever possible.
+
+## 2) Baseline Setup
+
+```bash
+# Version check
+nmap --version
+
+# Basic syntax check on a target list
+nmap -iL <TARGETS_FILE> -sn -n --reason -oA <OUT>-discovery
+```
+
+Use `-n` to skip DNS when speed and signal fidelity matter.
+
+## 3) Host Discovery Profiles
+
+```bash
+# Standard ICMP + common probes
+nmap -sn <TARGET> -n --reason -oA <OUT>-host-discovery
+
+# ARP discovery on local network segment
+nmap -sn -PR <TARGET> -n --reason -oA <OUT>-arp-discovery
+
+# Discovery with TCP SYN ping to common service ports
+nmap -sn -PS22,80,443,3389,445 <TARGET> -n --reason -oA <OUT>-syn-ping
+
+# Discovery with TCP ACK ping
+nmap -sn -PA80,443,3389 <TARGET> -n --reason -oA <OUT>-ack-ping
+
+# Discovery with UDP ping
+nmap -sn -PU53,67,68,123,161 <TARGET> -n --reason -oA <OUT>-udp-ping
+
+# Treat all hosts as up (when ping is blocked)
+nmap -Pn -sn <TARGET> -n --reason -oA <OUT>-no-ping
+```
+
+Use `-Pn` carefully because it increases scan time/noise on dead hosts.
+
+## 4) Port Scan Profiles
+
+### Fast Triage
+
+```bash
+# Top TCP ports, fast initial map
+nmap -sS --top-ports 1000 <TARGET> -n -T3 --reason -oA <OUT>-tcp-top1000
+
+# Fast scan preset
+nmap -sS -F <TARGET> -n -T3 --reason -oA <OUT>-tcp-fast
+```
+
+### Full Coverage
+
+```bash
+# Full TCP port sweep
+nmap -sS -p- <TARGET> -n -T3 --reason -oA <OUT>-tcp-all
+
+# UDP common ports
+nmap -sU --top-ports 200 <TARGET> -n -T2 --reason -oA <OUT>-udp-top200
+
+# Combined TCP + UDP (costly)
+nmap -sS -sU -p T:1-1000,U:53,67,68,69,123,137,138,139,161,162 <TARGET> -n -T2 --reason -oA <OUT>-tcp-udp-mixed
+```
+
+### Firewall State Mapping
+
+```bash
+# ACK scan to infer filtering
+nmap -sA -p 22,80,443,3389 <TARGET> -n --reason -oA <OUT>-ack-map
+
+# Window scan (stack-dependent)
+nmap -sW -p 22,80,443 <TARGET> -n --reason -oA <OUT>-window-scan
+
+# Maimon scan (niche behavior)
+nmap -sM -p 80,443 <TARGET> -n --reason -oA <OUT>-maimon
+```
+
+### Non-SYN Alternatives
+
+```bash
+# TCP connect scan (no raw sockets needed)
+nmap -sT -p- <TARGET> -n -T3 --reason -oA <OUT>-connect-all
+
+# NULL / FIN / Xmas (mainly for stateless filtering checks)
+nmap -sN -p 1-1024 <TARGET> -n --reason -oA <OUT>-null
+nmap -sF -p 1-1024 <TARGET> -n --reason -oA <OUT>-fin
+nmap -sX -p 1-1024 <TARGET> -n --reason -oA <OUT>-xmas
+```
+
+## 5) Service and OS Fingerprinting
+
+```bash
+# Service/version on known open ports
+nmap -sV -p 22,80,443,445,3389 <TARGET> -n --version-intensity 7 --reason -oA <OUT>-svc
+
+# Aggressive service probing
+nmap -sV --version-all <TARGET> -n --reason -oA <OUT>-svc-all
+
+# OS detection + traceroute
+nmap -O --osscan-guess --traceroute <TARGET> -n --reason -oA <OUT>-os-trace
+
+# Aggressive bundle (OS, version, scripts, traceroute)
+nmap -A <TARGET> -n -T3 --reason -oA <OUT>-aggressive
+```
+
+Use `-A` on limited targets first because it can be noisy.
+
+## 6) NSE Script Profiles
+
+Prefer service-targeted scripts over broad categories when possible.
+
+### Safe Baseline
+
+```bash
+# Default scripts on discovered services
+nmap -sC -sV <TARGET> -n -T3 --reason -oA <OUT>-default-scripts
+
+# Safe script category only
+nmap --script safe -sV <TARGET> -n --reason -oA <OUT>-safe-category
+```
+
+### Web
+
+```bash
+nmap -p80,443 --script http-title,http-headers,http-methods,http-enum,http-server-header <TARGET> -n -oA <OUT>-http-enum
+nmap -p443 --script ssl-cert,ssl-enum-ciphers,ssl-dh-params <TARGET> -n -oA <OUT>-tls-audit
+```
+
+### SMB / Windows
+
+```bash
+nmap -p139,445 --script smb-os-discovery,smb-protocols,smb-security-mode,smb2-security-mode <TARGET> -n -oA <OUT>-smb-posture
+nmap -p445 --script smb-enum-shares,smb-enum-users,smb-enum-domains <TARGET> -n -oA <OUT>-smb-enum
+```
+
+### DNS, SNMP, LDAP, RDP, NTP
+
+```bash
+nmap -p53 --script dns-recursion,dns-nsid,dns-service-discovery <TARGET> -n -oA <OUT>-dns
+nmap -p161 --script snmp-info,snmp-interfaces,snmp-processes,snmp-sysdescr <TARGET> -n -oA <OUT>-snmp
+nmap -p389,636 --script ldap-rootdse,ldap-search <TARGET> -n -oA <OUT>-ldap
+nmap -p3389 --script rdp-enum-encryption,rdp-ntlm-info <TARGET> -n -oA <OUT>-rdp
+nmap -p123 --script ntp-info,ntp-monlist <TARGET> -n -oA <OUT>-ntp
+```
+
+### Auth and Brute Categories (High Risk, Explicit Approval)
+
+```bash
+# Run only when scope explicitly allows authentication testing
+nmap --script auth -p 21,22,80,443,445 <TARGET> -n -oA <OUT>-auth-category
+nmap --script brute -p 21,22,80,443,445 <TARGET> -n --script-args brute.firstonly=true -oA <OUT>-brute-category
+```
+
+### Vuln Category (High Risk, Explicit Approval)
+
+```bash
+# Scope this to specific hosts/services after baseline confirmation
+nmap --script vuln -sV <TARGET> -n -T2 -oA <OUT>-vuln-category
+```
+
+Use `--script-args` for credentialed or tuned checks when needed.
+
+## 7) Firewall and Evasion Options
+
+Use only with written authorization and defined rules of engagement.
+
+```bash
+# Fragment packets
+nmap -sS -f <TARGET> -n -oA <OUT>-frag
+
+# Custom MTU (must be multiple of 8)
+nmap -sS --mtu 24 <TARGET> -n -oA <OUT>-mtu
+
+# Decoy scan
+nmap -sS -D RND:5 <TARGET> -n -oA <OUT>-decoy
+
+# Source port manipulation
+nmap -sS --source-port 53 <TARGET> -n -oA <OUT>-srcport53
+
+# Spoof MAC (local segment only)
+nmap -sS --spoof-mac 0 <TARGET> -n -oA <OUT>-spoof-mac
+
+# Append random payload bytes
+nmap -sS --data-length 32 <TARGET> -n -oA <OUT>-data-length
+```
+
+If evasion is authorized, document business justification and expected impact.
+
+## 8) Performance and Reliability Tuning
+
+```bash
+# Conservative and stealthier
+nmap -sS --top-ports 1000 <TARGET> -n -T2 --max-retries 2 --scan-delay 5ms -oA <OUT>-slow-steady
+
+# Balanced enterprise scan
+nmap -sS --top-ports 1000 <TARGET> -n -T3 --min-rate 100 --max-retries 2 -oA <OUT>-balanced
+
+# Faster scan in resilient environments
+nmap -sS --top-ports 1000 <TARGET> -n -T4 --min-rate 500 --max-retries 1 --host-timeout 10m -oA <OUT>-fast
+```
+
+Useful options:
+
+- `--min-rate` and `--max-rate` to control packet throughput.
+- `--min-hostgroup` and `--max-hostgroup` to tune parallel hosts.
+- `--min-parallelism` and `--max-parallelism` for probe concurrency.
+- `--max-rtt-timeout` and `--initial-rtt-timeout` for high latency paths.
+
+## 9) Professional Runbooks
+
+### External Perimeter (Breadth First)
+
+```bash
+nmap -sn <TARGET> -n --reason -oA <OUT>-01-discovery
+nmap -sS --top-ports 1000 <TARGET> -n -T3 --reason -oA <OUT>-02-tcp-top
+nmap -sV -p <OPEN_TCP_PORTS> <TARGET> -n --reason -oA <OUT>-03-version
+nmap --script safe -p <OPEN_TCP_PORTS> <TARGET> -n -oA <OUT>-04-safe-scripts
+```
+
+### Internal Network (Depth on Live Hosts)
+
+```bash
+nmap -sn -PR <TARGET> -n --reason -oA <OUT>-01-arp-discovery
+nmap -sS -p- <TARGET> -n -T3 --reason -oA <OUT>-02-tcp-all
+nmap -sU --top-ports 200 <TARGET> -n -T2 --reason -oA <OUT>-03-udp-top
+nmap -sV -O --traceroute <TARGET> -n -T3 --reason -oA <OUT>-04-fingerprint
+```
+
+### Active Directory Focus
+
+```bash
+nmap -p53,88,135,139,389,445,464,636,3268,3269,3389 -sS -sV <TARGET> -n -T3 -oA <OUT>-ad-core
+nmap -p389,636 --script ldap-rootdse,ldap-search <TARGET> -n -oA <OUT>-ad-ldap
+nmap -p445 --script smb-os-discovery,smb-security-mode,smb2-security-mode,smb-enum-shares <TARGET> -n -oA <OUT>-ad-smb
+```
+
+### Web and TLS Focus
+
+```bash
+nmap -p80,443,8080,8443 -sS -sV <TARGET> -n -T3 -oA <OUT>-web-ports
+nmap -p80,443,8080,8443 --script http-title,http-enum,http-methods,http-security-headers <TARGET> -n -oA <OUT>-web-scripts
+nmap -p443,8443 --script ssl-cert,ssl-enum-ciphers,ssl-dh-params <TARGET> -n -oA <OUT>-tls-scripts
+```
+
+## 10) Output and Reporting
+
+```bash
+# Save all major formats
+nmap -sS -sV <TARGET> -n --reason -oA <OUT>
+
+# Human-readable
+nmap -sS -sV <TARGET> -n --reason -oN <OUT>.nmap
+
+# XML for parsers/automation
+nmap -sS -sV <TARGET> -n --reason -oX <OUT>.xml
+
+# Grepable format for quick extraction
+nmap -sS -sV <TARGET> -n --reason -oG <OUT>.gnmap
+```
+
+Quick extraction examples:
+
+```bash
+# Open ports from gnmap output
+grep "/open/" <OUT>.gnmap
+
+# Open TCP services summary
+grep "/open/tcp/" <OUT>.gnmap | cut -d " " -f 2-
+```
+
+## 11) Common Pitfalls
+
+- Scanning UDP too broadly without timing controls can stall assessments.
+- Using `-Pn` on large ranges can create excessive noise and long runtimes.
+- Running intrusive NSE categories before baseline reconnaissance can break change windows.
+- Interpreting `open|filtered` as open without corroborating evidence leads to false positives.
+- Forgetting `-oA` impairs reproducibility and auditability.

--- a/skills/nmap-pentest-scans/references/tools.md
+++ b/skills/nmap-pentest-scans/references/tools.md
@@ -1,0 +1,8 @@
+# Nmap Pentest Scans Tools
+
+| Tool | URL |
+|---|---|
+| Nmap | https://nmap.org/ |
+| Nmap Reference Guide | https://nmap.org/book/man.html |
+| NSE Script Docs | https://nmap.org/book/nse.html |
+| Nmap NSE Script Index | https://nmap.org/nsedoc/ |

--- a/skills/nmap-pentest-scans/scripts/nmap_pentest_scans.py
+++ b/skills/nmap-pentest-scans/scripts/nmap_pentest_scans.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""nmap-pentest-scans script - AUTHORIZED SECURITY TESTING ONLY."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SHARED_DIR = Path(__file__).resolve().parents[2] / "autonomous-pentester" / "shared"
+if str(SHARED_DIR) not in sys.path:
+    sys.path.insert(0, str(SHARED_DIR))
+
+from pentest_common import (  # noqa: E402
+    load_payload,
+    render_result,
+    resolve_artifact_path,
+    resolve_output_file,
+    validate_scope,
+    write_placeholder_artifact,
+)
+
+
+SKILL_NAME = "nmap-pentest-scans"
+REPORT_STEM = "nmap-pentest-scans-report"
+GENERATED_OUTPUTS = [
+    "scan-plan.json",
+    "scan-plan.md",
+    "recommended-commands.txt",
+    "findings/nmap-pentest-findings.json",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build scope-validated Nmap command plans for host discovery, service "
+            "enumeration, and targeted script checks."
+        )
+    )
+    parser.add_argument("--scope", default="scope.json")
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--input", default=".")
+    parser.add_argument("--output", default=".")
+    parser.add_argument("--format", choices=["json", "md", "csv"], default="json")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--i-have-authorization", action="store_true")
+    parser.add_argument(
+        "--profile",
+        choices=["stealth", "balanced", "fast"],
+        default="balanced",
+        help="Scan profile for command tuning.",
+    )
+    parser.add_argument(
+        "--include-udp",
+        action="store_true",
+        help="Include recommended UDP command in generated plan.",
+    )
+    return parser.parse_args()
+
+
+def build_command_plan(target: str, profile: str, include_udp: bool) -> list[dict[str, str]]:
+    if profile == "stealth":
+        timing = "-T2"
+        rate = "--max-retries 2 --scan-delay 5ms"
+    elif profile == "fast":
+        timing = "-T4"
+        rate = "--min-rate 500 --max-retries 1 --host-timeout 10m"
+    else:
+        timing = "-T3"
+        rate = "--min-rate 100 --max-retries 2"
+
+    plan: list[dict[str, str]] = [
+        {
+            "stage": "host-discovery",
+            "command": f"nmap -sn {target} -n --reason -oA results/{target}-01-discovery",
+            "purpose": "Detect responsive hosts and collect probe reasons.",
+        },
+        {
+            "stage": "tcp-triage",
+            "command": (
+                f"nmap -sS --top-ports 1000 {target} -n {timing} {rate} --reason "
+                f"-oA results/{target}-02-tcp-top1000"
+            ),
+            "purpose": "Find common exposed TCP services quickly.",
+        },
+        {
+            "stage": "service-enum",
+            "command": (
+                f"nmap -sV -sC -p <OPEN_TCP_PORTS> {target} -n {timing} --reason "
+                f"-oA results/{target}-03-svc-default"
+            ),
+            "purpose": "Fingerprint service versions and run default safe scripts.",
+        },
+        {
+            "stage": "web-tls",
+            "command": (
+                f"nmap -p 80,443 --script http-title,http-headers,http-methods,ssl-cert "
+                f"{target} -n --script-timeout 30s -oA results/{target}-04-web-tls"
+            ),
+            "purpose": "Capture web fingerprinting and TLS certificate posture.",
+        },
+    ]
+
+    if include_udp:
+        plan.append(
+            {
+                "stage": "udp-followup",
+                "command": (
+                    f"nmap -sU --top-ports 200 {target} -n -T2 --reason "
+                    f"-oA results/{target}-05-udp-top200"
+                ),
+                "purpose": "Enumerate common UDP services after TCP baseline.",
+            }
+        )
+    return plan
+
+
+def build_finding(target: str) -> dict:
+    now = datetime.now(timezone.utc).isoformat()
+    return {
+        "finding_id": f"{SKILL_NAME.replace('-', '_')}-001",
+        "skill": SKILL_NAME,
+        "timestamp": now,
+        "target": target,
+        "title": "Nmap reconnaissance identified externally reachable services",
+        "cve": "N/A",
+        "cwe": "CWE-200",
+        "cvss_score": 6.5,
+        "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+        "owasp_category": "A05:2021 - Security Misconfiguration",
+        "mitre_attack": "TA0007 - Discovery",
+        "severity": "Medium",
+        "description": "Service exposure was identified and should be reviewed against hardened baseline policy.",
+        "proof_of_concept": "nmap -sS --top-ports 1000 <target> -n --reason",
+        "screenshot": "assets/findings/placeholder.png",
+        "remediation": "Restrict unnecessary network exposure and enforce service-level hardening controls.",
+        "references": ["https://nmap.org/docs.html", "https://nmap.org/book/nse.html"],
+        "status": "open",
+    }
+
+
+def write_plan_markdown(path: Path, target: str, profile: str, plan: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        f"# Nmap Plan for {target}",
+        "",
+        f"- profile: {profile}",
+        f"- generated_at: {datetime.now(timezone.utc).isoformat()}",
+        "",
+        "## Command Sequence",
+    ]
+    for item in plan:
+        lines.append(f"- [{item['stage']}] `{item['command']}`")
+        lines.append(f"  purpose: {item['purpose']}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_command_list(path: Path, plan: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = "\n".join(item["command"] for item in plan) + "\n"
+    path.write_text(payload, encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    scope_ok, scope_meta = validate_scope(args.target, args.scope)
+    report_path = resolve_output_file(args.output, args.format, REPORT_STEM)
+
+    if not scope_ok:
+        result = {
+            "status": "error",
+            "summary": "TARGET NOT IN AUTHORIZED SCOPE - ABORTING",
+            "artifacts": [str(report_path)],
+            "details": {
+                "skill": SKILL_NAME,
+                "target": args.target,
+                "scope": scope_meta,
+                "dry_run": args.dry_run,
+            },
+        }
+        render_result(result, report_path, args.format)
+        print(json.dumps(result, indent=2))
+        return 1
+
+    if not args.i_have_authorization and not args.dry_run:
+        result = {
+            "status": "error",
+            "summary": "You must pass --i-have-authorization to confirm written authorization.",
+            "artifacts": [str(report_path)],
+            "details": {
+                "skill": SKILL_NAME,
+                "target": args.target,
+                "scope": scope_meta,
+                "dry_run": args.dry_run,
+            },
+        }
+        render_result(result, report_path, args.format)
+        print(json.dumps(result, indent=2))
+        return 1
+
+    payload = load_payload(args.input)
+    plan = build_command_plan(args.target, args.profile, args.include_udp)
+    finding = build_finding(args.target)
+    artifacts: list[str] = []
+
+    if not args.dry_run:
+        plan_json = resolve_artifact_path(report_path.parent, "scan-plan.json")
+        write_placeholder_artifact(
+            plan_json,
+            {
+                "skill": SKILL_NAME,
+                "target": args.target,
+                "profile": args.profile,
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "plan": plan,
+                "input_payload": payload,
+            },
+        )
+        artifacts.append(str(plan_json))
+
+        plan_md = resolve_artifact_path(report_path.parent, "scan-plan.md")
+        write_plan_markdown(plan_md, args.target, args.profile, plan)
+        artifacts.append(str(plan_md))
+
+        cmd_txt = resolve_artifact_path(report_path.parent, "recommended-commands.txt")
+        write_command_list(cmd_txt, plan)
+        artifacts.append(str(cmd_txt))
+
+        findings_json = resolve_artifact_path(report_path.parent, "findings/nmap-pentest-findings.json")
+        write_placeholder_artifact(
+            findings_json,
+            {
+                "skill": SKILL_NAME,
+                "target": args.target,
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "findings": [finding],
+                "plan_summary": [item["stage"] for item in plan],
+            },
+        )
+        artifacts.append(str(findings_json))
+
+    result = {
+        "status": "ok",
+        "summary": "Dry run completed" if args.dry_run else "Skill executed",
+        "artifacts": artifacts + [str(report_path)],
+        "details": {
+            "skill": SKILL_NAME,
+            "target": args.target,
+            "scope": scope_meta,
+            "profile": args.profile,
+            "include_udp": args.include_udp,
+            "plan": plan,
+            "findings": [finding],
+            "expected_outputs": GENERATED_OUTPUTS,
+            "dry_run": args.dry_run,
+        },
+    }
+    render_result(result, report_path, args.format)
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/nmap-pentest-scans/scripts/nmap_pentest_scans.py
+++ b/skills/nmap-pentest-scans/scripts/nmap_pentest_scans.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -61,7 +62,16 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def normalize_target_basename(target: str) -> str:
+    """Normalize target values for safe filesystem basenames."""
+    normalized = re.sub(r"[^A-Za-z0-9._-]+", "-", target.strip())
+    normalized = normalized.strip("-._")
+    return normalized or "target"
+
+
 def build_command_plan(target: str, profile: str, include_udp: bool) -> list[dict[str, str]]:
+    target_basename = normalize_target_basename(target)
+
     if profile == "stealth":
         timing = "-T2"
         rate = "--max-retries 2 --scan-delay 5ms"
@@ -75,14 +85,17 @@ def build_command_plan(target: str, profile: str, include_udp: bool) -> list[dic
     plan: list[dict[str, str]] = [
         {
             "stage": "host-discovery",
-            "command": f"nmap -sn {target} -n --reason -oA results/{target}-01-discovery",
+            "command": (
+                f"nmap -sn {target} -n --reason "
+                f"-oA results/{target_basename}-01-discovery"
+            ),
             "purpose": "Detect responsive hosts and collect probe reasons.",
         },
         {
             "stage": "tcp-triage",
             "command": (
                 f"nmap -sS --top-ports 1000 {target} -n {timing} {rate} --reason "
-                f"-oA results/{target}-02-tcp-top1000"
+                f"-oA results/{target_basename}-02-tcp-top1000"
             ),
             "purpose": "Find common exposed TCP services quickly.",
         },
@@ -90,7 +103,7 @@ def build_command_plan(target: str, profile: str, include_udp: bool) -> list[dic
             "stage": "service-enum",
             "command": (
                 f"nmap -sV -sC -p <OPEN_TCP_PORTS> {target} -n {timing} --reason "
-                f"-oA results/{target}-03-svc-default"
+                f"-oA results/{target_basename}-03-svc-default"
             ),
             "purpose": "Fingerprint service versions and run default safe scripts.",
         },
@@ -98,7 +111,8 @@ def build_command_plan(target: str, profile: str, include_udp: bool) -> list[dic
             "stage": "web-tls",
             "command": (
                 f"nmap -p 80,443 --script http-title,http-headers,http-methods,ssl-cert "
-                f"{target} -n --script-timeout 30s -oA results/{target}-04-web-tls"
+                f"{target} -n --script-timeout 30s "
+                f"-oA results/{target_basename}-04-web-tls"
             ),
             "purpose": "Capture web fingerprinting and TLS certificate posture.",
         },
@@ -110,7 +124,7 @@ def build_command_plan(target: str, profile: str, include_udp: bool) -> list[dic
                 "stage": "udp-followup",
                 "command": (
                     f"nmap -sU --top-ports 200 {target} -n -T2 --reason "
-                    f"-oA results/{target}-05-udp-top200"
+                    f"-oA results/{target_basename}-05-udp-top200"
                 ),
                 "purpose": "Enumerate common UDP services after TCP baseline.",
             }

--- a/tests/scenarios/test_nmap_pentest_scans_regression.py
+++ b/tests/scenarios/test_nmap_pentest_scans_regression.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "skills" / "nmap-pentest-scans" / "scripts" / "nmap_pentest_scans.py"
+
+
+def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, check=False, capture_output=True, text=True)
+
+
+def main() -> int:
+    if not SCRIPT.exists():
+        print(json.dumps({"status": "skipped", "summary": "nmap-pentest-scans skill not present"}, indent=2))
+        return 0
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        scope = root / "scope.json"
+        out = root / "out.json"
+        scope.write_text(
+            json.dumps(
+                {
+                    "engagement_name": "Regression Scope",
+                    "authorized_by": "Security Team",
+                    "authorization_date": "2026-02-01",
+                    "rules_of_engagement": {
+                        "testing_window": "Mon-Fri 09:00-18:00 UTC",
+                        "dos_attacks_allowed": False,
+                        "destructive_actions_allowed": False,
+                        "data_exfil_live_data_allowed": False,
+                    },
+                    "in_scope_targets": [{"type": "ip_range", "value": "10.10.10.0/24"}],
+                    "out_of_scope": [],
+                    "emergency_contact": "+1-555-0100",
+                    "cvss_threshold_for_exploitation": 7.0,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        proc = run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--scope",
+                str(scope),
+                "--target",
+                "10.10.10.0/24",
+                "--input",
+                str(root),
+                "--output",
+                str(out),
+                "--format",
+                "json",
+                "--dry-run",
+            ]
+        )
+        if proc.returncode != 0:
+            print(f"nmap regression failure: dry-run failed\nstdout={proc.stdout}\nstderr={proc.stderr}")
+            return 1
+        if not out.exists():
+            print("nmap regression failure: output file missing")
+            return 1
+
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        plan = payload.get("details", {}).get("plan", [])
+        if not isinstance(plan, list) or not plan:
+            print("nmap regression failure: missing plan in output details")
+            return 1
+
+        for item in plan:
+            cmd = item.get("command", "")
+            if "results/10.10.10.0/24-" in cmd:
+                print("nmap regression failure: unsanitized target used in -oA output basename")
+                return 1
+            if " -oA results/" not in cmd:
+                print("nmap regression failure: missing -oA output command segment")
+                return 1
+
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "summary": "nmap-pentest-scans basename sanitization regression passed",
+                "script": str(SCRIPT),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_checks.bat
+++ b/tools/run_checks.bat
@@ -25,6 +25,9 @@ if errorlevel 1 exit /b 1
 python tests\scenarios\test_pentest_bug_bounty_programs.py
 if errorlevel 1 exit /b 1
 
+python tests\scenarios\test_nmap_pentest_scans_regression.py
+if errorlevel 1 exit /b 1
+
 python tests\scenarios\run_agentic_scenarios.py
 if errorlevel 1 exit /b 1
 


### PR DESCRIPTION
## Summary

- What changed
- Why it changed
- Impacted areas

## Validation

- [ ] `python tests/smoke/validate_all_skills.py`
- [ ] `python tests/smoke/run_smoke.py`
- [ ] `python tests/scenarios/run_agentic_scenarios.py`
- [ ] `python tests/scenarios/run_agentskills_reference_checks.py`
- [ ] `python tests/security/run_security_regressions.py`

If pentest skills changed:
- [ ] `python tests/smoke/validate_pentest_skills.py`
- [ ] `python tests/scenarios/test_pentest_skills.py`

## Skill Contract Checklist

- [ ] `SKILL.md` frontmatter valid and `name` matches folder
- [ ] `agents/openai.yaml` has required interface keys
- [ ] scripts honor `--dry-run` and output contract
- [ ] docs/references updated

## Release Notes

- [ ] Add or update `CHANGELOG.md` entry if user-facing behavior changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the nmap-pentest-scans skill pack to plan and orchestrate authorized Nmap scans with scope validation and deterministic artifacts. Updates README and CHANGELOG, increasing total skills to 44, and fixes output filename sanitization for CIDR/URL targets with a CI-backed regression test.

- **New Features**
  - New skill: skills/nmap-pentest-scans with SKILL.md, agent config, references, and script.
  - Safety controls: scope validation, explicit --i-have-authorization, and dry-run support.
  - Profiles and outputs: stealth/balanced/fast, optional UDP; emits scan-plan.json/md, recommended-commands.txt, findings JSON, and a report; adds reference docs and default prompt.

- **Bug Fixes**
  - Sanitized -oA output basenames for CIDR/URL targets; added regression test and wired it into CI and tools/run_checks.bat.

<sup>Written for commit 737b0b5ac0a65ad2067232f4190c87f3c0fc226e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

