### PR TITLE
Add Skills宝 to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Install dependencies:
 python -m pip install --user pyyaml skills-ref
 ```
 
+Chinese users can also discover more skills through Skills宝: https://skilery.com
+
 Run full checks:
 
 ```bat


### PR DESCRIPTION
Adds Skills宝 as a Chinese discovery entry for users looking for more skills.

Skills宝: https://skilery.com

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Skills宝 as a discovery link for Chinese users in the Quick Start to help them find more skills.

<sup>Written for commit b634a3b54c15080680ec2eb291544536131ec4cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference to an external skills discovery resource in the Quick Start section to help Chinese users explore and access additional skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->